### PR TITLE
feat/공통컴포넌트-필터-드롭다운

### DIFF
--- a/public/Images/drop-down/chevron-down-blue-lg.svg
+++ b/public/Images/drop-down/chevron-down-blue-lg.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="10" viewBox="0 0 18 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L9 9L17 1" stroke="#1B92FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/Images/drop-down/chevron-down-lg.svg
+++ b/public/Images/drop-down/chevron-down-lg.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="10" viewBox="0 0 18 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L9 9L17 1" stroke="#1F1F1F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/shared/components/drop-down/filter-drop-down/DropDownButton.tsx
+++ b/src/components/shared/components/drop-down/filter-drop-down/DropDownButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { Button, Typography, useMediaQuery, useTheme } from "@mui/material";
+import Image from "next/image";
+import { COLORS } from "@/public/theme/colors";
+
+interface DropDownButtonProps {
+  label: string;
+  isSelected: boolean;
+  onClick?: () => void;
+}
+
+export default function DropDownButton({
+  label,
+  isSelected,
+  onClick,
+}: DropDownButtonProps) {
+  const theme = useTheme();
+  const isTablet = useMediaQuery(theme.breakpoints.down("tablet"));
+  const iconSize = isTablet ? 10 : 15;
+  const buttonStyle = {
+    justifyContent: "space-between",
+    alignItems: "center",
+    textTransform: "none",
+    display: "flex",
+    width: isTablet ? "fit-content" : "328px",
+    height: isTablet ? "36px" : "64px",
+    padding: isTablet ? "6px 10px 6px 14px" : "16px 24px",
+    gap: isTablet ? "6px" : "12px",
+    border: `1px solid ${
+      isSelected
+        ? COLORS.PrimaryBlue[300]
+        : isTablet
+        ? COLORS.Line[200]
+        : COLORS.Grayscale[100]
+    }`,
+    borderRadius: isTablet ? "8px" : "16px",
+    backgroundColor: isSelected ? COLORS.PrimaryBlue[50] : COLORS.White[100],
+    boxShadow: "4px 4px 10px rgba(238, 238, 238, 0.1)",
+  };
+
+  const iconSrc = isSelected
+    ? "/images/drop-down/chevron-down-blue-lg.svg"
+    : "/images/drop-down/chevron-down-lg.svg";
+
+  return (
+    <Button onClick={onClick} sx={buttonStyle}>
+      <Typography
+        variant={isTablet ? "M_14" : "M_18"}
+        sx={{
+          color: isSelected ? COLORS.PrimaryBlue[300] : COLORS.Grayscale[50],
+        }}
+        paddingRight={isTablet ? "5px" : "0px"}
+      >
+        {label}
+      </Typography>
+      <Image src={iconSrc} alt="드롭다운" width={iconSize} height={iconSize} />
+    </Button>
+  );
+}

--- a/src/components/shared/components/drop-down/filter-drop-down/DropDownList.tsx
+++ b/src/components/shared/components/drop-down/filter-drop-down/DropDownList.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
+import { COLORS } from "@/public/theme/colors";
+import CustomScrollY from "@/src/lib/customScrollY";
+
+interface DropDownListProps {
+  type: "region" | "service";
+  items: readonly string[];
+  selectedItem?: string;
+  onSelect: (value: string) => void;
+}
+
+export default function DropDownList({
+  type,
+  items,
+  selectedItem,
+  onSelect,
+}: DropDownListProps) {
+  const isRegion = type === "region";
+  const theme = useTheme();
+  const isTablet = useMediaQuery(theme.breakpoints.down("tablet"));
+
+  const wrapperWidth = isTablet ? (isRegion ? 150 : 89) : 328;
+  const wrapperHeight = isTablet
+    ? isRegion
+      ? 179
+      : 144
+    : isRegion
+    ? 320
+    : 256;
+
+  const getItemStyle = (isSelected: boolean) => ({
+    boxSizing: "border-box",
+    height: isTablet ? "36px" : "64px",
+    padding: isTablet ? "6px 14px" : "12px 16px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    cursor: "pointer",
+    backgroundColor: isSelected ? COLORS.PrimaryBlue[50] : "transparent",
+    "&:hover": {
+      backgroundColor: COLORS.PrimaryBlue[50],
+    },
+  });
+
+  const listContent = items.map((item) => {
+    const isSelected = selectedItem === item;
+    return (
+      <Box
+        key={item}
+        onClick={() => onSelect(item)}
+        sx={getItemStyle(isSelected)}
+      >
+        <Typography variant={isTablet ? "M_14" : "M_16"} whiteSpace="nowrap">
+          {item}
+        </Typography>
+      </Box>
+    );
+  });
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        top: "100%",
+        left: 0,
+        mt: "4px",
+        width: wrapperWidth,
+        height: wrapperHeight,
+        backgroundColor: COLORS.White[100],
+        borderRadius: isTablet ? "8px" : "16px",
+        boxShadow: "4px 4px 10px rgba(224, 224, 224, 0.25)",
+        border: `1px solid ${COLORS.Line[200]}`,
+        overflow: "hidden",
+        zIndex: 10,
+        backgroundImage: isRegion
+          ? "linear-gradient(to right, transparent calc(50% - 0.5px), #E0E0E0 0, transparent calc(50% + 0.5px))"
+          : "none",
+        backgroundRepeat: "no-repeat",
+        backgroundSize: "100% 100%",
+      }}
+    >
+      <Box
+        sx={{
+          height: "100%",
+          overflowY: type === "region" ? "auto" : "hidden",
+          overflowX: "hidden",
+          ...CustomScrollY,
+        }}
+      >
+        <Box
+          sx={{
+            display: isRegion ? "grid" : "block",
+            gridTemplateColumns: isRegion ? "1fr 1fr" : "none",
+          }}
+        >
+          {listContent}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/shared/components/drop-down/filter-drop-down/DropDownWrapper.tsx
+++ b/src/components/shared/components/drop-down/filter-drop-down/DropDownWrapper.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import DropDownButton from "./DropDownButton";
+import DropDownList from "./DropDownList";
+import { ServiceType, RegionType } from "@/src/lib/constants";
+import { Box } from "@mui/material";
+
+interface DropDownWrapperProps {
+  type: "region" | "service";
+}
+
+export default function DropDownWrapper({ type }: DropDownWrapperProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<string>(
+    type === "region" ? "지역" : "서비스"
+  );
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSelectedItem(type === "region" ? "지역" : "서비스");
+  }, [type]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const toggleDropdown = () => setIsOpen((prev) => !prev);
+
+  const items = type === "region" ? RegionType : ServiceType;
+  const displayItems = ["전체", ...items];
+
+  const handleSelect = (value: string) => {
+    setSelectedItem(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <Box ref={wrapperRef} sx={{ position: "relative" }}>
+      <DropDownButton
+        label={selectedItem}
+        isSelected={isOpen}
+        onClick={toggleDropdown}
+      />
+      {isOpen && (
+        <DropDownList
+          type={type}
+          items={displayItems}
+          selectedItem={selectedItem}
+          onSelect={handleSelect}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,25 @@
+export const ServiceType = ["소형이사", "가정이사", "사무실이사"] as const;
+export type Service = (typeof ServiceType)[number];
+
+export const RegionType = [
+  "서울",
+  "경기",
+  "인천",
+  "강원",
+  "충북",
+  "충남",
+  "세종",
+  "대전",
+  "전북",
+  "전남",
+  "경주",
+  "경북",
+  "경남",
+  "대구",
+  "울산",
+  "부산",
+  "제주",
+] as const;
+export type Region = (typeof RegionType)[number];
+
+export const PATH = { login: "/auth/login", signup: "/auth/signup" };

--- a/src/lib/customScrollY.ts
+++ b/src/lib/customScrollY.ts
@@ -1,0 +1,19 @@
+import { COLORS } from "@/public/theme/colors";
+
+import { SxProps, Theme } from "@mui/material";
+
+const CustomScrollY: SxProps<Theme> = {
+  "&::-webkit-scrollbar": {
+    width: "6px",
+  },
+  "&::-webkit-scrollbar-thumb": {
+    backgroundColor: COLORS.Grayscale[200],
+    borderRadius: "4px",
+    minHeight: "24px",
+  },
+  "&::-webkit-scrollbar-track": {
+    backgroundColor: "transparent",
+  },
+};
+
+export default CustomScrollY;

--- a/src/lib/dayjsConfig.ts
+++ b/src/lib/dayjsConfig.ts
@@ -1,0 +1,10 @@
+//TODO: lib 폴더 생기면 옮기기
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko";
+
+dayjs.extend(relativeTime);
+dayjs.locale("ko");
+
+export default dayjs;

--- a/stories/DropDownButton.stories.tsx
+++ b/stories/DropDownButton.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import DropDownButton from "@/src/components/shared/components/drop-down/filter-drop-down/DropDownButton";
+
+const meta: Meta<typeof DropDownButton> = {
+  title: "drop-down/filter/DropDownButton",
+  component: DropDownButton,
+} satisfies Meta<typeof DropDownButton>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: "지역",
+    isSelected: false,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    label: "서울",
+    isSelected: true,
+  },
+};

--- a/stories/DropDownWrapper.stories.tsx
+++ b/stories/DropDownWrapper.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj, Decorator } from "@storybook/react";
+import DropDownWrapper from "@/src/components/shared/components/drop-down/filter-drop-down/DropDownWrapper";
+const withContainer: Decorator = (Story) => {
+  return (
+    <div
+      style={{
+        width: "500px",
+        height: "300px",
+        margin: "100px auto",
+        position: "relative",
+        background: "#fff",
+        padding: "24px",
+        boxSizing: "border-box",
+      }}
+    >
+      <Story />
+    </div>
+  );
+};
+const meta = {
+  title: "drop-down/filter/DropDownWrapper",
+  component: DropDownWrapper,
+  decorators: [withContainer],
+  parameters: {
+    layout: "centered",
+    viewport: {
+      defaultViewport: "desktop",
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof DropDownWrapper>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RegionDropdown: Story = {
+  args: { type: "region", label: "지역" },
+  parameters: {
+    docs: {
+      description: {
+        story: "지역 드롭다운을 2열 레이아웃으로 보여줍니다.",
+      },
+    },
+  },
+};
+
+export const ServiceDropdown: Story = {
+  args: { type: "service", label: "서비스" },
+  parameters: {
+    docs: {
+      description: {
+        story: "서비스 유형 드롭다운을 1열 레이아웃으로 보여줍니다.",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## 🧚 변경사항 설명

- /src/lib 폴더 생성
- 지역/서비스 필터 버튼, 드롭다운 UI 구현
- 경로 (/src/components/shared/components/drop-down/filter-drop-down/)
- 스토리북 drop-down 메뉴에 추가했습니다. 
## 🧑🏻‍🏫 To-do

[ ] 스크롤바 상하 여백 만들기

## 🎤 공유 사항

- DropDownWrapper 컴포넌트에서 type="region" || "service"를 props로 받아서 해당 항목 아이템 목록을 렌더링합니다. 
![image](https://github.com/user-attachments/assets/930fcf7f-e745-404e-bd9e-43c04d706126)
- 외부 클릭 시 자동으로 닫히도록 useRef 사용하여 구현하였습니다.

- DropDownButton 컴포넌트에서 현재 선택된 값을 표시하고, 클릭시 onClick 핸들러 통해서 드롭다운 열림/닫힘 상태 토글되게했습니다.
  - isSelected 여부에 따라 스타일 변경됩니다.

- DropDownList 컴포넌트는 드롭다운으로 표시될 항목 리스트입니다. type에 따라 (지역:2열 grid + 스크롤바, 서비스 1열) 렌더링됩니다. 
  - region일 경우에 스크롤바가 생깁니다.
  - onSelect 콜백으로 선택한 값을 상위 컴포넌트에 전달합니다.
 
- 프로필 및 알림 드롭다운은 스토리북 작업중이라서 따로 PR 올리겠습니다. 
## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

#26 

## 📸 스크린샷
![Screenshot 2025-05-22 at 16 40 23](https://github.com/user-attachments/assets/05101ac7-2859-44a8-a194-dfc3036c9184)


