### PR TITLE
feat/프론트 sentry 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# Sentry Config File
+.env.local

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -12,4 +13,31 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  org: "part4-team1",
+  project: "moving-fe",
+
+  // 옵션들
+  // // Only print logs for uploading source maps in CI
+  // silent: !process.env.CI,
+
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+  // Upload a larger set of source maps for prettier stack traces (increases build time)
+  // widenClientFileUpload: true,
+
+  // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+  // This can increase your server load as well as your hosting bill.
+  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+  // side errors will fail.
+  // tunnelRoute: "/monitoring",
+
+  // Automatically tree-shake Sentry logger statements to reduce bundle size
+  // disableLogger: true,
+
+  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+  // See the following for more information:
+  // https://docs.sentry.io/product/crons/
+  // https://vercel.com/docs/cron-jobs
+  // automaticVercelMonitors: true,
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.0.1",
@@ -18,10 +19,12 @@
     "@mui/material": "^7.1.0",
     "@mui/material-nextjs": "^7.1.0",
     "@mui/x-date-pickers": "^8.3.1",
+    "@sentry/nextjs": "^9.28.0",
     "@tanstack/react-query": "^5.76.1",
     "@types/js-cookie": "^3.0.6",
     "axios": "^1.9.0",
     "dayjs": "^1.11.13",
+    "import-in-the-middle": "^1.14.0",
     "init": "^0.1.2",
     "js-cookie": "^3.0.5",
     "next": "15.3.2",
@@ -29,6 +32,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.4",
+    "require-in-the-middle": "^7.5.2",
     "storybook": "^8.6.13",
     "zod": "^3.25.32",
     "zustand": "^5.0.4"

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function GlobalError({ error }: { error: Error }) {
+  useEffect(() => {
+    Sentry.captureException(error, {
+      tags: { source: "global-error" },
+      extra: {
+        digest: (error as any).digest,
+        message: error.message,
+        stack: error.stack,
+        pathname: window.location.pathname, // 현재 페이지 경로
+      },
+    });
+  }, [error]);
+
+  return (
+    <html>
+      <body />
+    </html>
+  );
+}

--- a/src/lib/sentry/discord.ts
+++ b/src/lib/sentry/discord.ts
@@ -1,0 +1,40 @@
+export async function sendDiscordAlert({
+  url,
+  method,
+  error,
+}: {
+  url: string;
+  method: string;
+  error: unknown;
+}) {
+  const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+  if (!DISCORD_WEBHOOK_URL) return;
+
+  const err = error instanceof Error ? error : new Error(String(error));
+  const truncate = (text: string | undefined, max = 800) =>
+    text?.slice(0, max) || "No stack";
+
+  const content = [
+    "🚨 **[500 Error Alert]**",
+    `**Method**: \`${method}\``,
+    `**URL**: ${url}`,
+    `**Message**: \`${err.message}\``,
+    "**Stack:**",
+    `\`\`\`${truncate(err.stack)}\`\`\``,
+  ].join("\n");
+
+  try {
+    const res = await fetch(DISCORD_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+    if (!res.ok) {
+      console.error("❌ Discord Webhook 전송 실패", res.statusText);
+    } else {
+      console.log("👾 Discord Webhook 전송 성공");
+    }
+  } catch (e) {
+    console.error("❌ Discord Webhook 오류", e);
+  }
+}

--- a/src/lib/sentry/errorHandler.ts
+++ b/src/lib/sentry/errorHandler.ts
@@ -1,0 +1,36 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { sendDiscordAlert } from "./discord";
+
+export function withErrorHandler(
+  handler: (req: NextRequest) => Promise<NextResponse>
+) {
+  return async function wrappedHandler(req: NextRequest) {
+    try {
+      return await handler(req);
+    } catch (error) {
+      // Sentry
+      Sentry.captureException(error, {
+        tags: {
+          route: req.url,
+          method: req.method,
+        },
+        extra: {
+          timestamp: new Date().toISOString(),
+        },
+      });
+
+      //  Discord
+      await sendDiscordAlert({
+        url: req.url,
+        method: req.method,
+        error,
+      });
+
+      return NextResponse.json(
+        { statusCode: 500, message: "Internal Server Error" },
+        { status: 500 }
+      );
+    }
+  };
+}

--- a/src/lib/sentry/instrumentation-client.ts
+++ b/src/lib/sentry/instrumentation-client.ts
@@ -1,0 +1,12 @@
+//브라우저 측 오류, 퍼포먼스, 세션 리플레이 감지
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+  tracesSampleRate: 0,
+
+  debug: false,
+});
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart; // 선택사항: 페이지 전환 시작 시 Sentry 세션 추적

--- a/src/lib/sentry/sentry.server.config.ts
+++ b/src/lib/sentry/sentry.server.config.ts
@@ -1,0 +1,9 @@
+//API Routes, SSR, RSC 같은 서버 환경의 에러 및 성능 모니터링
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENV || "development",
+  tracesSampleRate: 0, // 퍼포먼스 추적 꺼두고 에러만 추적
+  debug: false, // 디버그 모드 비활성화
+});


### PR DESCRIPTION
## 🧚 변경사항 설명

- 백엔드랑 동일하게 sentry 기본 설정했습니다. 
- 어제 멘토링때 여쭤봤더니 보통 500에러만 알림을 보내도록 해두신다고 해서 500번대 서버 에러 발생시 sentry 전송, 디스코드 웹훅 알림 연결 설정해두었습니다. 

## 🧑🏻‍🏫 To-do

- 추후 디스코드 프론트, 백엔드 각각 에러 알림 채널 생성
- sentry 관련, 디스코드 웹훅 URL 환경변수를 .env(백엔드) / .env.local (프론트)에 추가해야합니다. 

## 🎤 공유 사항

- 에러 로그 레벨까지 정해서 관리하는 것은 저희 현재 상황에서는 조금 오버엔지니어링이 될 수 있을 것 같아서 알 수 없는 500번대 에러 정도만 다같이 공유할 수 있도록 "sentry 도입해서 에러 중앙화 관리를 해봤다." 정도로만 도입해봐도 좋을 것 같습니다. 

## 🤙🏻 관련 이슈


Closes #84 

## 📸 스크린샷
- 500 에러 발생시키는 임의의 테스트 경로 생성하여 테스트
![Screenshot 2025-06-12 004059](https://github.com/user-attachments/assets/e17acd33-4ed9-474c-8092-6e81e3e4ba34)
- 저희 디스코드 PR알림 웹훅 URL을 환경변수 추가하여 테스트시 동작확인
![Screenshot 2025-06-12 003821](https://github.com/user-attachments/assets/b8f3eba7-0a65-4bcf-9b3f-4aa627e43ced)
- sentry 이슈 페이지에도 알림 전송 확인
![Screenshot 2025-06-12 004144](https://github.com/user-attachments/assets/2e922650-cf48-4067-b9c0-fcfc2ba160ba)

