### PR TITLE
Feat/sentry fe

### DIFF
--- a/src/app/api/test-error/route.ts
+++ b/src/app/api/test-error/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { sendDiscordAlert } from "@/src/lib/sentry/discord";
+
+export async function GET(request: Request) {
+  try {
+    throw new Error("🔥 프론트 500 에러 테스트");
+  } catch (error) {
+    await sendDiscordAlert({
+      url: request.url,
+      method: "GET",
+      error,
+    });
+
+    return NextResponse.json({ message: "테스트 에러 발생" }, { status: 500 });
+  }
+}

--- a/src/lib/sentry/discord.ts
+++ b/src/lib/sentry/discord.ts
@@ -11,16 +11,16 @@ export async function sendDiscordAlert({
   if (!DISCORD_WEBHOOK_URL) return;
 
   const err = error instanceof Error ? error : new Error(String(error));
-  const truncate = (text: string | undefined, max = 800) =>
-    text?.slice(0, max) || "No stack";
+  const stack = maskStackTrace(err.stack);
+  const message = err.message;
 
   const content = [
     "🚨 **[500 Error Alert]**",
     `**Method**: \`${method}\``,
     `**URL**: ${url}`,
-    `**Message**: \`${err.message}\``,
+    `**Message**: \`${message}\``,
     "**Stack:**",
-    `\`\`\`${truncate(err.stack)}\`\`\``,
+    `\`\`\`${stack}\`\`\``,
   ].join("\n");
 
   try {
@@ -37,4 +37,20 @@ export async function sendDiscordAlert({
   } catch (e) {
     console.error("❌ Discord Webhook 오류", e);
   }
+}
+
+/**
+ * 스택트레이스 경로 마스킹
+ */
+function maskStackTrace(stack?: string): string {
+  if (!stack) return "No stack";
+
+  const normalized = stack.replace(/\\/g, "/"); // Windows 경로 슬래시 변환
+  const projectRoot = process.cwd().replace(/\\/g, "/");
+
+  return normalized
+    .split("\n")
+    .slice(0, 5)
+    .map((line) => line.replace(projectRoot, "[app-root]"))
+    .join("\n");
 }


### PR DESCRIPTION
## 🧚 변경사항 설명

- 프론트 에러 알림 디스코드 웹훅 연결 테스트 완료
- 알림 전송시 로컬 경로 마스킹 처리
- 테스트 파일 추가 (src\app\api\test-error\route.ts)

## 🧑🏻‍🏫 To-do

- 모든 팀원 연결 테스트 완료 후 테스트 파일 삭제 

## 🎤 공유 사항

- 노션 프론트 .env.local 페이지에 환경변수 추가해두었습니다. 

## 🤙🏻 관련 이슈


Closes #84

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/120ea11c-fb36-4a7d-a62e-75b640264595)
