### PR TITLE
Feat/기사님 마이페이지 api 연동, 반응형 구현, 리뷰 훅 연결

### DIFF
--- a/src/api/mover/api.ts
+++ b/src/api/mover/api.ts
@@ -38,7 +38,7 @@ export interface MoverProfileRequest {
   serviceRegion: Record<ServiceRegion, boolean>;
 }
 
-/** 일반 유저 프로필 등록 api */
+/** 기사 프로필 등록 api */
 export const registerMoverProfile = async (data: MoverProfileRequest) => {
   try {
     const response = await apiClient.post("/mover", data);
@@ -114,3 +114,30 @@ export const requestTargetedEstimate = async (
 
   return response.data;
 };
+
+/** 기사님 프로필 카드 데이터 타입 */
+export interface MoverProfileCardData {
+  id: string;
+  nickname: string;
+  intro: string;
+  imageUrl: string;
+  averageRating: number;
+  experience: number;
+  reviewCount: number;
+  confirmedEstimateCount: number;
+  serviceType: Record<ServiceType, boolean>;
+  serviceRegion: Record<ServiceRegion, boolean>;
+}
+
+/**
+ * 기사님의 프로필 카드 정보 조회 API
+ */
+export const fetchMoverProfileCard =
+  async (): Promise<MoverProfileCardData> => {
+    try {
+      const response = await apiClient.get<MoverProfileCardData>("/mover/me");
+      return response.data;
+    } catch (error) {
+      throw new Error("기사님 프로필 정보를 불러오지 못했습니다.");
+    }
+  };

--- a/src/api/mover/hooks.ts
+++ b/src/api/mover/hooks.ts
@@ -8,6 +8,7 @@ import {
   updateGeneralMoverProfile,
   getMoverDetail,
   requestTargetedEstimate,
+  fetchMoverProfileCard,
 } from "./api";
 
 interface UseEstimateRequestQueryParams {
@@ -70,5 +71,12 @@ export const useRequestTargetedEstimate = () => {
       requestId: string;
       moverProfileId: string;
     }) => requestTargetedEstimate(requestId, moverProfileId),
+  });
+};
+/** 기사님 마이페이지 프로필 카드 조회 hook */
+export const useMoverMypage = () => {
+  return useQuery({
+    queryKey: ["moverMypage"],
+    queryFn: fetchMoverProfileCard,
   });
 };

--- a/src/api/review/hooks.ts
+++ b/src/api/review/hooks.ts
@@ -9,5 +9,6 @@ export const useMoverReviews = (
   return useQuery({
     queryKey: ["moverReviews", moverId, page, take],
     queryFn: () => getMoverReviews(moverId, page, take),
+    enabled: !!moverId && moverId !== "undefined", // moverId가 있을 때만 API 호출 (빈 값이나 undefined일 때는 호출 안함)
   });
 };

--- a/src/app/mover/mypage/page.tsx
+++ b/src/app/mover/mypage/page.tsx
@@ -1,43 +1,34 @@
 "use client";
-import { Box, Divider, Typography } from "@mui/material";
-import { ReviewChart } from "@/src/components/shared/components/review/review-chart/ReviewChart";
-import { ReviewList } from "@/src/components/shared/components/review/ReviewList";
-//TODO: moverDetail 파일에서 더미데이터 import -> API연결 후 제거
-import {
-  mockReviewData,
-  mockReviews,
-  mockMoverData,
-} from "@/src/components/mover/MoverDetail";
-import { useTheme } from "@mui/material/styles";
+import { Box } from "@mui/material";
 import { MyPageProfileSection } from "@/src/components/mover/mypage/MyPageProfileSection";
+import { ReviewSection } from "@/src/components/mover/mypage/ReviewSection";
+import { useMoverMypage } from "@/src/api/mover/hooks";
 
 export default function MyPage() {
-  const theme = useTheme();
+  const { data: moverProfileCardData, isPending } = useMoverMypage();
+
+  if (isPending || !moverProfileCardData) return <div>로딩중입니다...</div>; //TODO: 스켈레톤 추가
 
   return (
-    <Box display="flex" flexDirection="column" alignItems="center" pt="32px">
+    <Box
+      sx={{
+        maxWidth: "1400px",
+        margin: "0 auto",
+        padding: "24px 16px",
+        paddingX: [3, 9, 3],
+        minWidth: 0,
+        overflow: "hidden",
+      }}
+    >
       {/* 프로필 섹션 */}
-      <MyPageProfileSection data={mockMoverData} />
+      <Box sx={{ paddingBottom: "40px", marginBottom: "40px" }}>
+        <MyPageProfileSection data={moverProfileCardData} />
+      </Box>
 
       {/* 리뷰 섹션 */}
-      <Box mb="40px" width="100%" maxWidth="1400px" px="24px">
-        <Typography
-          sx={{
-            fontSize: [18, 20, 24],
-            fontWeight: 700,
-            color: theme.palette.Black[300],
-            marginBottom: "32px",
-          }}
-        >
-          리뷰 (178)
-        </Typography>
-        <ReviewChart data={mockReviewData} />
-      </Box>
-
-      {/* 댓글 섹션 */}
-      <Box width="100%" maxWidth="1400px" px="24px">
-        <ReviewList reviews={mockReviews} itemsPerPage={5} />
-      </Box>
+      {moverProfileCardData.id && (
+        <ReviewSection moverId={moverProfileCardData.id} />
+      )}
     </Box>
   );
 }

--- a/src/components/mover/mypage/CardListProfile-refactor.tsx
+++ b/src/components/mover/mypage/CardListProfile-refactor.tsx
@@ -1,12 +1,22 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
-import { CardData } from "@/src/types/card";
+import {
+  Box,
+  Button,
+  Stack,
+  Typography,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
 import Image from "next/image";
-
 import { joinAddress } from "@/src/lib/joinAddress";
-import { typeMapper } from "@/src/lib/typeMapper";
+import { typeMapperFromRecord } from "@/src/lib/typeMapper";
+import { MoverProfileCardData } from "@/src/api/mover/api";
+import {
+  convertToServiceRegionArray,
+  convertRegionToKoreanLabels,
+} from "@/src/utils/util";
 
 interface CardProps {
-  data: CardData;
+  data: MoverProfileCardData;
   onMyClick?: () => void;
   onBasicClick?: () => void;
   buttonLabels?: {
@@ -19,7 +29,7 @@ interface CardProps {
  * @file CardListProfile-refactor.tsx
  * @description
  * 기사님 소개 카드 컴포넌트
- * 기존 CardListProfile 컴포넌트 리팩토링함
+ * 기존 CardListProfile 컴포넌트 수정해서 기사님 마이페이지에 사용중
  *
  */
 export const CardListProfile = ({
@@ -27,65 +37,85 @@ export const CardListProfile = ({
   onMyClick,
   onBasicClick,
   buttonLabels,
-  reverseButtons,
+  reverseButtons = false,
 }: CardProps) => {
-  const buttons = [
+  const theme = useTheme();
+  const isDesktopUp = useMediaQuery(theme.breakpoints.up("desktop"));
+
+  const buttonPrimary = (
     <Button
       key="primary"
       onClick={onMyClick}
       variant="contained"
-      sx={(theme) => ({
-        width: ["100%", 296, 280],
-        height: [48, 48, 64],
-        bgcolor: theme.palette.PrimaryBlue[300],
-        borderRadius: ["8px", "8px", "16px"],
-      })}
+      sx={{
+        px: "68px",
+        py: "12px",
+        flex: 1,
+        minWidth: 0,
+        maxWidth: "100%",
+        borderRadius: "16px",
+        overflow: "hidden",
+      }}
     >
       <Typography
-        sx={(theme) => ({
+        sx={{
           fontSize: [16, 16, 20],
           lineHeight: ["26px", "26px", "32px"],
           fontWeight: 600,
           color: theme.palette.White[100],
-        })}
+          whiteSpace: "nowrap",
+        }}
       >
         {buttonLabels?.primary ?? "견적 보내기"}
       </Typography>
-    </Button>,
+    </Button>
+  );
 
+  const buttonSecondary = (
     <Button
       key="secondary"
       onClick={onBasicClick}
       variant="outlined"
-      sx={(theme) => ({
-        width: ["100%", 296, 280],
-        height: [48, 48, 64],
-        borderRadius: ["8px", "8px", "16px"],
+      sx={{
+        px: "68px",
+        py: "12px",
+        flex: 1,
+        minWidth: 0,
+        maxWidth: "100%",
+        borderRadius: "16px",
         border: `1px solid ${theme.palette.Grayscale[300]}`,
-      })}
+      }}
     >
       <Typography
-        sx={(theme) => ({
+        sx={{
           fontSize: [16, 16, 20],
           lineHeight: ["26px", "26px", "32px"],
           fontWeight: 600,
           color: theme.palette.Grayscale[300],
-        })}
+          whiteSpace: "nowrap",
+        }}
       >
         {buttonLabels?.secondary ?? "반려"}
       </Typography>
-    </Button>,
-  ];
+    </Button>
+  );
+
+  const buttons = reverseButtons
+    ? [buttonSecondary, buttonPrimary]
+    : [buttonPrimary, buttonSecondary];
+
   return (
     <>
       <Box
         display="flex"
         flexDirection="column"
         justifyContent="space-between"
-        bgcolor={"transparent"}
-        gap={"10px"}
-        width="100%"
-        minWidth={["327px", "600px", "1000px"]}
+        sx={{
+          flexGrow: 1,
+          overflow: "hidden",
+          minWidth: ["375px", "600px", "744px"],
+          maxWidth: "100%",
+        }}
       >
         <Box
           display="flex"
@@ -111,14 +141,34 @@ export const CardListProfile = ({
             direction="row"
             spacing={["14px", "16px"]}
             mb="24px"
+            flexWrap="nowrap"
             justifyContent={["flex-start", "flex-start", "space-between"]}
+            alignItems="center"
+            width="100%"
           >
-            <Box
-              display={["inline-block", "inline-block", "none"]}
-              width={[46, 46, 56]}
-              height={[46, 46, 56]}
-              position="relative"
-            ></Box>
+            {!isDesktopUp && (
+              <Box
+                width="46px"
+                height="46px"
+                position="relative"
+                flexShrink={0}
+                sx={{
+                  borderRadius: "100px",
+                  overflow: "hidden",
+                  backgroundColor: "#D9D9D9",
+                }}
+              >
+                <Image
+                  src={data.imageUrl || "/Images/profile/maleProfile.svg"}
+                  alt="프로필 이미지"
+                  fill
+                  style={{
+                    objectFit: "cover",
+                  }}
+                />
+              </Box>
+            )}
+
             <Box maxWidth={["80%", "80%", "45%"]}>
               <Typography
                 sx={(theme) => ({
@@ -128,7 +178,7 @@ export const CardListProfile = ({
                   color: theme.palette.Black[300],
                 })}
               >
-                {data.name}
+                {data.nickname}
               </Typography>
               <Typography
                 sx={(theme) => ({
@@ -141,17 +191,23 @@ export const CardListProfile = ({
                   textOverflow: "ellipsis",
                 })}
               >
-                {data.message}
+                {data.intro}
               </Typography>
             </Box>
-            <Stack
-              direction={["column", "row", "row"]}
-              spacing={["8px", "8px", "11px"]}
-              display={["none", "none", "flex"]}
-              gap={["8px", "8px", "11px"]}
-            >
-              {reverseButtons ? [...buttons].reverse() : buttons}
-            </Stack>
+            {/* 데스크탑 전용 버튼 */}
+            {isDesktopUp && (
+              <Stack
+                direction="row"
+                spacing={2}
+                sx={{
+                  flexShrink: 1,
+                  flexWrap: "wrap",
+                  minWidth: 400,
+                }}
+              >
+                {buttons}
+              </Stack>
+            )}
           </Stack>
 
           {/* 내부 박스 (이미지, 정보) */}
@@ -159,7 +215,7 @@ export const CardListProfile = ({
             display="flex"
             flexDirection="row"
             alignItems="center"
-            gap="20px"
+            gap="24px"
             padding={["10px", "24px 18px"]}
             border="1px solid"
             borderRadius="6px"
@@ -169,44 +225,45 @@ export const CardListProfile = ({
               boxShadow: "4px 4px 16px 0px rgba(233, 233, 233, 0.1)",
             })}
           >
-            {/* 1. 프로필 이미지 */}
-            <Box
-              width="80px"
-              height="80px"
-              position="relative"
-              flexShrink={0}
-              sx={{
-                borderRadius: "100px",
-                overflow: "hidden",
-                backgroundColor: "#D9D9D9",
-              }}
-            >
-              <Image
-                src={data.imgSrc}
-                alt="프로필 이미지"
-                fill
-                style={{
-                  objectFit: "cover",
+            {/* 프로필 이미지 */}
+            {isDesktopUp && (
+              <Box
+                width="80px"
+                height="80px"
+                position="relative"
+                flexShrink={0}
+                sx={{
+                  borderRadius: "100px",
+                  overflow: "hidden",
+                  backgroundColor: "#D9D9D9",
                 }}
-              />
-            </Box>
-
-            {/* 2. 정보 영역 */}
+              >
+                <Image
+                  src={data.imageUrl || "/Images/profile/maleProfile.svg"}
+                  alt="프로필 이미지"
+                  fill
+                  style={{
+                    objectFit: "cover",
+                  }}
+                />
+              </Box>
+            )}
+            {/* 정보 */}
             <Box
               display="flex"
               flexDirection="column"
               justifyContent="center"
               flex={1}
             >
-              {/* 별점, 경력, 확정 */}
+              {/* 별점, 경력, 확정 건수 */}
               <Stack
                 direction="row"
                 spacing="16px"
                 alignItems="center"
-                justifyContent={["space-between", "flex-start"]}
+                justifyContent="flex-start"
                 flexGrow={1}
               >
-                {/* 평점 */}
+                {/* 별점 */}
                 <Box
                   display="flex"
                   justifyContent="space-between"
@@ -215,7 +272,7 @@ export const CardListProfile = ({
                 >
                   <Image
                     src="/Images/star/star_active.svg"
-                    alt="별점 사진"
+                    alt="별점"
                     width={20}
                     height={20}
                   />
@@ -227,7 +284,7 @@ export const CardListProfile = ({
                       color: theme.palette.Black[300],
                     })}
                   >
-                    {data.rating}
+                    {data.averageRating.toFixed(1)}
                   </Typography>
                   <Typography
                     sx={(theme) => ({
@@ -237,11 +294,11 @@ export const CardListProfile = ({
                       color: theme.palette.Grayscale[300],
                     })}
                   >
-                    ({data.count})
+                    ({data.reviewCount})
                   </Typography>
                 </Box>
-                {/* Divider */}
-                <Box height={14} border={"1px solid #E6E6E6"}></Box>
+
+                <Box height={14} border="1px solid #E6E6E6" />
                 {/* 경력 */}
                 <Box display="flex" gap="16px">
                   <Typography
@@ -264,12 +321,12 @@ export const CardListProfile = ({
                       whiteSpace: "nowrap",
                     })}
                   >
-                    {data.career}년
+                    {data.experience}년
                   </Typography>
                 </Box>
-                {/* Divider */}
-                <Box height={14} border={"1px solid #E6E6E6"}></Box>
-                {/* 확정 */}
+
+                <Box height={14} border="1px solid #E6E6E6" />
+                {/* 확정 건수 */}
                 <Box display="flex" gap="4px">
                   <Typography
                     sx={(theme) => ({
@@ -283,7 +340,7 @@ export const CardListProfile = ({
                       },
                     })}
                   >
-                    {data.confirm}건 <span>확정</span>
+                    {data.confirmedEstimateCount}건 <span>확정</span>
                   </Typography>
                 </Box>
               </Stack>
@@ -299,16 +356,22 @@ export const CardListProfile = ({
                       backgroundColor: theme.palette.Background[400],
                     })}
                   >
-                    <Typography sx={{ fontSize: 14, color: "#999999" }}>
+                    <Typography
+                      sx={{
+                        fontSize: 14,
+                        color: theme.palette.Grayscale[400],
+                        whiteSpace: "nowrap",
+                      }}
+                    >
                       제공 서비스
                     </Typography>
                   </Box>
                   <Typography sx={{ fontSize: 14 }}>
-                    {joinAddress(typeMapper(data.types))}
+                    {joinAddress(typeMapperFromRecord(data.serviceType || {}))}
                   </Typography>
                 </Box>
 
-                <Box display="flex" gap="8px" alignItems="center">
+                <Box display="flex" gap="8px" alignItems="center" pr="8px">
                   <Box
                     borderRadius="4px"
                     px="6px"
@@ -317,12 +380,30 @@ export const CardListProfile = ({
                       backgroundColor: theme.palette.Background[400],
                     })}
                   >
-                    <Typography sx={{ fontSize: 14, color: "#999999" }}>
+                    <Typography
+                      sx={{
+                        fontSize: 14,
+                        color: theme.palette.Grayscale[400],
+                        whiteSpace: "nowrap",
+                      }}
+                    >
                       지역
                     </Typography>
                   </Box>
-                  <Typography sx={{ fontSize: 14 }}>
-                    {joinAddress(data.address)}
+                  <Typography
+                    sx={{
+                      fontSize: 14,
+                      whiteSpace: {
+                        xs: "normal",
+                        md: "nowrap",
+                      },
+                    }}
+                  >
+                    {data.serviceRegion
+                      ? convertRegionToKoreanLabels(
+                          convertToServiceRegionArray(data.serviceRegion)
+                        ).join(", ")
+                      : ""}
                   </Typography>
                 </Box>
               </Box>
@@ -330,14 +411,16 @@ export const CardListProfile = ({
           </Box>
         </Box>
 
-        {/* tablet, mobile시 버튼 있는 곳 */}
-        <Box
-          display={["flex", "flex", "none"]}
-          gap={["8px", "8px", "11px"]}
-          flexDirection={["column", "row", "row"]}
-        >
-          {reverseButtons ? [...buttons].reverse() : buttons}
-        </Box>
+        {!isDesktopUp && (
+          <Box
+            display="flex"
+            gap={["8px", "8px", "11px"]}
+            flexDirection={["column", "row"]}
+            mt={2}
+          >
+            {buttons}
+          </Box>
+        )}
       </Box>
     </>
   );

--- a/src/components/mover/mypage/CardListProfileWrapper.tsx
+++ b/src/components/mover/mypage/CardListProfileWrapper.tsx
@@ -3,10 +3,19 @@
 import { CardListProfile } from "@/src/components/mover/mypage/CardListProfile-refactor";
 import { CardData } from "@/src/types/card";
 import Image from "next/image";
-import { Box, Button, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import { MoverProfileCardData } from "@/src/api/mover/api";
+import { useRouter } from "next/navigation";
+import { PATH } from "@/src/lib/constants";
 
 interface Props {
-  data: CardData;
+  data: MoverProfileCardData;
 }
 /**
  * @file CardListProfileWrapper.tsx
@@ -18,11 +27,14 @@ interface Props {
  * 데스크탑 사이즈에서  reverseButtons를 통해 버튼 위치 반전하도록함
  */
 export default function CardListProfileWrapper({ data }: Props) {
+  const router = useRouter();
+  const theme = useTheme();
+  const isDesktopUp = useMediaQuery(theme.breakpoints.up("desktop"));
   return (
     <CardListProfile
       data={data}
-      onMyClick={() => console.log("기본 정보 수정 클릭")}
-      onBasicClick={() => console.log("내 프로필 수정 클릭")}
+      onMyClick={() => router.push(PATH.moverProfileEdit)}
+      onBasicClick={() => router.push(PATH.moverEdit)}
       buttonLabels={{
         secondary: (
           <Box component="span" display="inline-flex" alignItems="center">
@@ -49,7 +61,7 @@ export default function CardListProfileWrapper({ data }: Props) {
           </Box>
         ),
       }}
-      reverseButtons // 버튼 순서 반전
+      reverseButtons={isDesktopUp} // 버튼 순서 반전
     />
   );
 }

--- a/src/components/mover/mypage/MyPageProfileSection.tsx
+++ b/src/components/mover/mypage/MyPageProfileSection.tsx
@@ -3,10 +3,11 @@
 import { Box, Divider, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import CardListProfileWrapper from "@/src/components/mover/mypage/CardListProfileWrapper";
-import { CardData } from "@/src/types/card";
+
+import { MoverProfileCardData } from "@/src/api/mover/api";
 
 interface MyPageProfileSectionProps {
-  data: CardData;
+  data: MoverProfileCardData;
 }
 
 export const MyPageProfileSection = ({ data }: MyPageProfileSectionProps) => {
@@ -14,13 +15,17 @@ export const MyPageProfileSection = ({ data }: MyPageProfileSectionProps) => {
 
   return (
     <Box width="100%" display="flex" justifyContent="center" mb="32px">
-      <Box width="100%" maxWidth="1400px" px="24px">
+      <Box
+        width="100%"
+        px="16px"
+        sx={{
+          mx: "auto",
+        }}
+      >
         <Typography variant="SB_24">마이페이지</Typography>
-
-        <Box mt="32px">
+        <Box mt="32px" mx="0">
           <CardListProfileWrapper data={data} />
         </Box>
-
         <Divider
           sx={{
             width: "100%",

--- a/src/components/mover/mypage/ReviewSection.tsx
+++ b/src/components/mover/mypage/ReviewSection.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { Box } from "@mui/material";
+import { ReviewList } from "@/src/components/shared/components/review/ReviewList";
+import { useMoverReviews } from "@/src/api/review/hooks";
+import { ReviewData, ReviewStatistics } from "@/src/types/common";
+import { useState } from "react";
+
+interface ReviewSectionProps {
+  moverId: string;
+}
+
+export const ReviewSection = ({ moverId }: ReviewSectionProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const { data: reviewData } = useMoverReviews(moverId, currentPage, 5);
+
+  const reviewStatistics: ReviewStatistics = {
+    average: reviewData?.rating?.average || 0,
+    score: reviewData?.rating?.count || { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+    max: Math.max(
+      ...Object.values(
+        reviewData?.rating.count || { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+      )
+    ),
+  };
+
+  const reviews: ReviewData[] =
+    reviewData?.reviews.map((review) => ({
+      id: Math.random(), // 임시 ID 생성
+      author: review.customerName,
+      date: review.createdAt,
+      rating: review.rating,
+      content: review.comment,
+    })) || [];
+
+  if (!reviewData) return null;
+
+  return (
+    <Box
+      sx={{
+        paddingBottom: "40px",
+        marginBottom: "40px",
+      }}
+    >
+      <ReviewList
+        reviews={reviews}
+        onPageChange={setCurrentPage}
+        totalPages={Math.ceil((reviewData?.total || 0) / 5)}
+        currentPage={currentPage}
+        total={reviewData?.total || 0}
+        reviewStatistics={reviewStatistics}
+      />
+    </Box>
+  );
+};

--- a/src/components/profile/RegionSelector.tsx
+++ b/src/components/profile/RegionSelector.tsx
@@ -7,7 +7,7 @@ interface RegionSelectorProps {
   onRegionToggle: (region: ServiceRegion) => void;
 }
 
-const regionLabels: Record<ServiceRegion, string> = {
+export const regionLabels: Record<ServiceRegion, string> = {
   [ServiceRegion.SEOUL]: "서울",
   [ServiceRegion.GYEONGGI]: "경기",
   [ServiceRegion.INCHEON]: "인천",

--- a/src/components/shared/components/CustomLayout.tsx
+++ b/src/components/shared/components/CustomLayout.tsx
@@ -25,7 +25,8 @@ export const CustomLayout = ({ children }: CustomLayoutProps) => {
     PATH.moverEstimateConfirm,
     PATH.moverEstimateReject,
   ];
-  const noPaddingPages = [PATH.userEstimateHistory];
+  // padding 적용이 필요 없는 페이지
+  const noPaddingPages = [PATH.userEstimateHistory, PATH.moverMypage];
   const subHeaderPages = [
     PATH.userRequest,
     PATH.userEstimate,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -45,6 +45,11 @@ export const PATH = {
   /** 기사 프로필 수정 페이지 (/mover/profile/edit) */
   moverProfileEdit: "/mover/profile/edit",
 
+  /**기사 기본정보 수정(/mover/edit) */
+  moverEdit: "/mover/edit",
+
+  /**기사 마이페이지 (/mover/mypage) */
+  moverMypage: "/mover/mypage",
   /** 기사가 받은 견적 리스트 페이지 (/mover/estimate/requested) */
   moverRequest: "/mover/estimate/requested",
 

--- a/src/lib/typeMapper.ts
+++ b/src/lib/typeMapper.ts
@@ -7,3 +7,14 @@ const typeMap: Record<string, string> = {
 export const typeMapper = (types: string[]): string[] => {
   return types.map((type) => typeMap[type] || type); // 못 찾으면 원래 값 반환
 };
+
+/**
+ * Record 형태의 서비스 타입을 배열로 변환하는 함수
+ */
+export const typeMapperFromRecord = (
+  types: Record<string, boolean>
+): string[] => {
+  return Object.entries(types)
+    .filter(([_, value]) => value)
+    .map(([key]) => typeMap[key] || key);
+};

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,3 +1,4 @@
+import { regionLabels } from "../components/profile/RegionSelector";
 import { MOVER_LIST } from "../lib/mockData";
 import { ServiceType, ServiceRegion } from "@/src/types/common";
 
@@ -93,5 +94,16 @@ export const convertToServiceRegionObject = (
       [region]: regions.includes(region),
     }),
     {} as Record<ServiceRegion, boolean>
+  );
+};
+
+/**서비스 지역을 한글 라벨로 변환  */
+export const convertRegionToKoreanLabels = (
+  regions: ServiceRegion[] | string[] | undefined
+): string[] => {
+  if (!regions || !Array.isArray(regions)) return [];
+
+  return regions.map(
+    (region) => regionLabels[region as ServiceRegion] ?? region
   );
 };


### PR DESCRIPTION
## 🧚 변경사항 설명
5e5b0036892d52f089079e182e01388186adfa7b: 기사님 프로필 카드부분 api 연동 /mover/me
e031fc7afbad0d9dcbd7b38f19d84910257a92c4: 반응형 구현 
d68002d8f25f2910a8c8c816bec49b2744e26c90: 리뷰 훅 연결, 리뷰 섹션 분리
471978e87d6c8cda349cd96c6da54e749deef59e: 커스텀 레이아웃으로 기본 패딩이 적용되어 화면 사이즈 줄일때, 카드컴포넌트가 가려지는 현상 (카드 컴포넌트 내의 버튼 크기 때문에 카트 컴포넌트에 minwidth를 줌)이 발생
-> 조순님께서 만들어두신 CustomLayout 파일에 패딩 적용이 필요없는 페이지로 전체 패딩 레이아웃 제외 시키고 페이지에서 자페 패딩 적용
![image](https://github.com/user-attachments/assets/cc57ccba-17f2-4d95-a424-e600821db148)

## 🧑🏻‍🏫 To-do

- 기사님 찾기 페이지 PR
- google 로그인

## 🎤 공유 사항

- 리뷰 차트 모바일 반응형 부분 조순님께서 수정해주실겁니다. 

## 🤙🏻 관련 이슈

Closes #104 

## 📸 스크린샷
![Screenshot 2025-06-21 at 21 41 47](https://github.com/user-attachments/assets/76890c95-acc0-43ac-847e-16daca477807)

