### PR TITLE
Feat/프론트 구글 OAuth 연동

### DIFF
--- a/src/app/oauth/page.tsx
+++ b/src/app/oauth/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSnackbar } from "@/src/hooks/snackBarHooks";
+import { AuthStore } from "@/src/store/authStore";
+import { Box, CircularProgress, Typography } from "@mui/material";
+import { getCustomerProfile } from "@/src/api/customer/api";
+import { fetchMoverProfileCard } from "@/src/api/mover/api";
+
+export default function OAuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { openSnackbar } = useSnackbar();
+  const login = AuthStore((state) => state.login);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    const refreshToken = searchParams.get("refreshToken");
+    const userInfoParam = searchParams.get("userInfo");
+
+    if (token && userInfoParam) {
+      try {
+        // 백엔드에서 전달받은 사용자 정보 파싱
+        const userInfo = JSON.parse(decodeURIComponent(userInfoParam));
+
+        // 백엔드에서 받은 역할 사용
+        const role = userInfo.role as "CUSTOMER" | "MOVER";
+
+        // 로그인 상태 저장
+        login(token, refreshToken || "", userInfo);
+
+        openSnackbar("소셜 로그인에 성공했습니다!", "success");
+
+        // 프로필 존재 여부 확인 (API 호출 TODO: 불필요시 제거)
+        const checkProfileAndRedirect = async () => {
+          try {
+            if (role === "MOVER") {
+              // 기사님 프로필 조회
+              await fetchMoverProfileCard();
+              router.replace("/mover");
+            } else {
+              // 고객 프로필 조회
+              await getCustomerProfile();
+              router.replace("/");
+            }
+          } catch (error) {
+            // 프로필 없을시 프로필 등록 페이지로 이동
+            if (role === "MOVER") {
+              router.replace("/mover/profile/register");
+            } else {
+              router.replace("/customer/profile/register");
+            }
+          }
+        };
+
+        checkProfileAndRedirect();
+      } catch (error) {
+        console.error("OAuth 콜백 처리 중 에러:", error);
+        openSnackbar("로그인 처리 중 오류가 발생했습니다.", "error");
+        router.replace("/auth/user/login");
+      }
+    } else {
+      openSnackbar("로그인 토큰을 받지 못했습니다.", "error");
+      router.replace("/auth/user/login");
+    }
+  }, [searchParams, login, openSnackbar, router]);
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      minHeight="100vh"
+      gap={2}
+    >
+      <CircularProgress size={40} />
+    </Box>
+  );
+}

--- a/src/components/auth/SnsLoginSection.tsx
+++ b/src/components/auth/SnsLoginSection.tsx
@@ -1,5 +1,7 @@
-import { Stack, Typography } from "@mui/material";
+import { Stack, Typography, Box } from "@mui/material";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
+import { API_BASE_URL } from "@/src/lib/constants";
 
 interface SnsLoginSectionProps {
   title: string;
@@ -8,31 +10,62 @@ interface SnsLoginSectionProps {
 
 export const SnsLoginSection = ({ isSmall, title }: SnsLoginSectionProps) => {
   const size = isSmall ? 54 : 72;
+  const pathname = usePathname();
+
+  const handleGoogleLogin = () => {
+    // 현재 로그인 페이지 경로에 따라 역할 결정
+    const role = pathname.includes("/mover/") ? "mover" : "customer";
+    // 세션에 역할을 저장하고 OAuth로 리디렉션
+    window.location.href = `${API_BASE_URL}/auth/login/google/role/${role}`;
+  };
+  const handleKakaoLogin = () => {
+    // TODO: 카카오 로그인 구현
+  };
+
+  const handleNaverLogin = () => {
+    // TODO: 네이버 로그인 구현
+  };
+
+  //버튼 호버 스타일
+  const snsButtonStyle = {
+    cursor: "pointer",
+    transition: "all 0.3s ease-in-out",
+    transform: "scale(1)",
+    filter: "drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1))",
+    "&:hover": {
+      transform: "scale(1.05)",
+      filter: "drop-shadow(0 6px 10px rgba(0, 0, 0, 0.2))",
+    },
+  };
+
   return (
     <Stack spacing={[3, 3, 4]} alignItems={"center"}>
       <Typography variant={isSmall ? "R_12" : "R_20"}>{title}</Typography>
       <Stack direction={"row"} spacing={[3, 3, 4]}>
-        <Image
-          src={"/Images/icon-btn/google_login.svg"}
-          alt="google"
-          width={size}
-          height={size}
-          style={{ cursor: "pointer" }}
-        />
-        <Image
-          src={"/Images/icon-btn/kakao_login.svg"}
-          alt="kakao"
-          width={size}
-          height={size}
-          style={{ cursor: "pointer" }}
-        />
-        <Image
-          src={"/Images/icon-btn/naver_login.svg"}
-          alt="naver"
-          width={size}
-          height={size}
-          style={{ cursor: "pointer" }}
-        />
+        <Box sx={snsButtonStyle} onClick={handleGoogleLogin}>
+          <Image
+            src={"/Images/icon-btn/google_login.svg"}
+            alt="google"
+            width={size}
+            height={size}
+          />
+        </Box>
+        <Box sx={snsButtonStyle} onClick={handleKakaoLogin}>
+          <Image
+            src={"/Images/icon-btn/kakao_login.svg"}
+            alt="kakao"
+            width={size}
+            height={size}
+          />
+        </Box>
+        <Box sx={snsButtonStyle} onClick={handleNaverLogin}>
+          <Image
+            src={"/Images/icon-btn/naver_login.svg"}
+            alt="naver"
+            width={size}
+            height={size}
+          />
+        </Box>
       </Stack>
     </Stack>
   );

--- a/src/components/shared/components/modal/components/InfoChip.tsx
+++ b/src/components/shared/components/modal/components/InfoChip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Typography, useTheme, useMediaQuery } from "@mui/material";
-import { styled } from "@mui/system";
+import { styled } from "@mui/material/styles";
 
 interface InfoBadgeProps {
   label: string; // 표시할 텍스트


### PR DESCRIPTION
## 🧚 변경사항 설명

c962b53a85260f000a1538bceef2a205687e30f0:
-  고객/기사 로그인 페이지 접근에 따라 role을 구분해서 로그인 성공 후 각각 프로필 등록 페이지로 리다이렉트하도록 구현
- 소셜 로그인 버튼 이미지에 호버 효과 추가

39368d4c119f8c552730a1beb4d0242487d3ebca: infoChip 컴포넌트 mui import 에러 있어서 수정함

## 🧑🏻‍🏫 To-do

- QA

## 🎤 공유 사항

관련 공유사항 노션 참고해주세요. 
https://www.notion.so/21ad9fa672ba80309851ede45193ff93?source=copy_link

## 🤙🏻 관련 이슈

Closes #110

## 📸 스크린샷
![Screenshot 2025-06-23 at 04 54 50](https://github.com/user-attachments/assets/f2730066-e9ca-47eb-85b0-cd1971ed74d3)
