### PR TITLE
117 feat qa fix UI feedback/ QA체크리스트 작업

### DIFF
--- a/src/components/customer/request/EstimateRequestFlow.tsx
+++ b/src/components/customer/request/EstimateRequestFlow.tsx
@@ -181,7 +181,12 @@ export default function EstimateRequestFlow() {
   // 7. 실제 화면 렌더링
   return (
     <>
-      <Box sx={{ paddingTop: isSmall ? "24px" : "40px" }}>
+      <Box
+        sx={{
+          paddingTop: isSmall ? "24px" : "40px",
+          paddingBottom: isSmall ? 0 : "170px",
+        }}
+      >
         {step === 1 && <Step1_MoveType onSelect={handleSelectStep1} />}
         {step === 2 && (
           <Step2_MoveDate

--- a/src/components/mover/estimate/requested/ReceivedRequestsFlow.tsx
+++ b/src/components/mover/estimate/requested/ReceivedRequestsFlow.tsx
@@ -430,6 +430,7 @@ export default function ReceivedRequestsFlow() {
                     display: "flex",
                     flexDirection: "column",
                     gap: ["24px", "32px", "48px"],
+                    marginBottom: ["24px", "32px", "48px"],
                   }}
                 >
                   {filteredItems.map((item, index) => {

--- a/src/components/mover/estimate/requested/ReceivedRequestsFlow.tsx
+++ b/src/components/mover/estimate/requested/ReceivedRequestsFlow.tsx
@@ -114,7 +114,15 @@ export default function ReceivedRequestsFlow() {
   // 실제 API로 받은 데이터 목록 정리
   const estimateItems = useMemo(() => {
     if (!data?.pages) return [];
-    return data.pages.flatMap((page) => page.items);
+    const allItems = data.pages.flatMap((page) => page.items);
+    const seen = new Set<string>();
+    const uniqueItems = allItems.filter((item) => {
+      if (seen.has(item.requestId)) return false;
+      seen.add(item.requestId);
+      return true;
+    });
+
+    return uniqueItems;
   }, [data?.pages]);
 
   // 필터링된 데이터 적용

--- a/src/components/shared/components/date-picker/Calendar.tsx
+++ b/src/components/shared/components/date-picker/Calendar.tsx
@@ -23,8 +23,6 @@ export const Calendar = ({ onChange, value, onAccept }: CalendarProps) => {
     <Box
       sx={{
         width: isSmall ? "327px" : "640px",
-        minHeight: isSmall ? "410px" : "612px",
-        height: isSmall ? "410px" : "612px",
         overflow: "visible", // 잘림 방지
 
         // 캘린더 레이아웃
@@ -75,7 +73,7 @@ export const Calendar = ({ onChange, value, onAccept }: CalendarProps) => {
 
         // 요일 헤더
         ".MuiDayCalendar-weekDayLabel": {
-          width: isSmall ? 42 : 64,
+          width: isSmall ? 40 : 64,
           height: isSmall ? 42 : 64,
           ...(isSmall ? theme.typography.M_13 : theme.typography.M_20),
         },
@@ -88,7 +86,7 @@ export const Calendar = ({ onChange, value, onAccept }: CalendarProps) => {
           color: "black",
           border: "none",
           "&.Mui-selected": {
-            backgroundColor: theme.palette.PrimaryBlue[500],
+            backgroundColor: theme.palette.PrimaryBlue[300],
             color: "white",
           },
         },


### PR DESCRIPTION
## 🧚 변경사항 설명

- 받은 요청 페이지의 무한스크롤 부분, 견적 요청 페이지의 페이지에 하단 여백(각각 margin, padding) 추가하여 피그마 내 디자인 구현 
- Calendar컴포넌트 6주 이상의 달에서는 '선택완료'버튼 잘려보이는 현상 해결 위해 고정 height 제거 및 화면사이즈 줄였을 때의 요일헤더-날짜 간 줄맞춤
 (https://www.notion.so/Calendar-218d9fa672ba80d3adeed591b9d900af?source=copy_link)
- 필터링 이후 무한스크롤 기능 시 key값 중복 에러 발생 해결(아래 노션페이지에 자세히 기재)
(https://www.notion.so/key-21cd9fa672ba80888d55c1f8e19aac6a?source=copy_link)
## 🧑🏻‍🏫 To-do

- [ ] 추가되는 QA사항 담당업무 추가 시 작업
- [ ] 발표 PPT 제작

## 🎤 공유 사항
-  Calendar컴포넌트 6주 이상의 달에서는 '선택완료'버튼 잘려보이는 현상 해결 위해 공통컴포넌트인 Calendar컴포넌트에서 고정 height 제거하는 등 약간의 수정사항 있습니다.  : 5dbebb79a8b38d3fd4ca5de8c7889f29bf9bbc33

## 🤙🏻 관련 이슈

x

## 📸 스크린샷

- 견적 요청 시, paddingBottom 추가함으로써 기존에 딱붙어있던 페이지 하단에 여백을 줌
![image](https://github.com/user-attachments/assets/4c928438-3360-424a-94ed-0bd4f6818daa)

- Calendar 컴포넌트 6주 이상인 달에도 '선택완료' 버튼 잘려보이지 않도록 수정함
![image](https://github.com/user-attachments/assets/19f40fe5-883a-4808-834f-b89362ce9d72)

- 받은 요청 조회 시, 필터링이후 무한스크롤 동작하면 필터링된 값으로 무한스크롤 가능(key 중복 에러 x)
- 무한스크롤 부분 하단에 marginBottom 추가함으로써 여백을 줌
![image](https://github.com/user-attachments/assets/fa449b0e-5e69-4a43-b7c8-7668b778b7fe)
