### PR TITLE
chip 및 OfferStatus 수정

### DIFF
--- a/src/api/customer/request/api.ts
+++ b/src/api/customer/request/api.ts
@@ -25,7 +25,6 @@ export enum EstimateRequestStatus {
 
 export enum EstimateOfferStatus {
   REQUESTED = "REQUESTED", // 고객이 견적 요청 보냄 (기사 입장에선 대기 중)
-  SUBMITTED = "SUBMITTED", // 기사님이 견적서 보냄
   REJECTED = "REJECTED", // 기사님이 반려함
   CONFIRMED = "CONFIRMED", // 고객이 확정함
   CANCELED = "CANCELED", // 고객이 다른 기사 선택 → 자동 취소

--- a/src/app/customer/wishlist/page.tsx
+++ b/src/app/customer/wishlist/page.tsx
@@ -28,7 +28,7 @@ const Wishlist = () => {
       moverId: item.id,
       price: 0,
       comment: "",
-      status: EstimateOfferStatus.REQUESTED,
+      status: EstimateOfferStatus.PENDING,
       requestStatus: EstimateRequestStatus.PENDING,
       confirmedCount: item.confirmed_estimate_count,
       isTargeted: false,

--- a/src/components/customer/estimate/HistoryDetail.tsx
+++ b/src/components/customer/estimate/HistoryDetail.tsx
@@ -45,7 +45,7 @@ export default function HistoryDetail({
         <Stack gap={"24px"}>
           <EstimateSection title="견적 상세">
             <CardListMover
-              data={data}
+              data={{ ...data, status: data.offerStatus }}
               onLikeClick={() => {
                 const moverId = data.moverId;
                 if (data.mover.isLiked) {
@@ -96,7 +96,7 @@ export default function HistoryDetail({
           <EstimateInfo info={data} />
         </EstimateSection>
 
-        <Label status={data.status} />
+        <Label status={data.offerStatus} />
       </Stack>
 
       {/* 데스크탑 SNS */}

--- a/src/components/shared/components/card/CardListCompleteState.tsx
+++ b/src/components/shared/components/card/CardListCompleteState.tsx
@@ -4,7 +4,7 @@ import { ChipData } from "@/src/types/card";
 import dayjs from "@/src/lib/dayjsConfig";
 import { formatKoreanDate } from "@/src/lib/formatKoreanDate";
 import {
-  EstimateRequestStatus,
+  EstimateOfferStatus,
   MinimalAddress,
   ServiceType,
 } from "@/src/types/common";
@@ -22,7 +22,7 @@ export interface OfferEstimateCardData {
   moveType: ServiceType;
   offerId: string;
   price: number;
-  status: EstimateRequestStatus;
+  status: EstimateOfferStatus;
   toAddressMinimal: MinimalAddress;
 }
 interface CardProps {

--- a/src/components/shared/components/card/CardListCost.tsx
+++ b/src/components/shared/components/card/CardListCost.tsx
@@ -6,7 +6,6 @@ import { COLORS } from "@/public/theme/colors";
 import { ChipData } from "@/src/types/card";
 import {
   EstimateOfferStatus,
-  EstimateRequestStatus,
   MinimalAddress,
   ServiceType,
 } from "@/src/types/common";
@@ -23,7 +22,6 @@ export interface HistoryEstimateCardData {
   offerId: string;
   price: number;
   offerStatus: EstimateOfferStatus;
-  requestStatus: EstimateRequestStatus;
   toAddressMinimal: MinimalAddress;
   mover: MoverProfile;
 }
@@ -34,13 +32,19 @@ interface CardProps {
 }
 
 export const CardListCost = ({ data, onLikeClick }: CardProps) => {
+  const status =
+    "offerStatus" in data
+      ? data.offerStatus
+      : "status" in data
+        ? data.status
+        : undefined;
   // 카드 데이터
   const info = data.mover;
   // Chip 데이터
   const chips: ChipData[] = [
     {
       chipType: data.moveType,
-      status: data.requestStatus,
+      status,
       isTargeted: data.isTargeted,
     },
   ];

--- a/src/components/shared/components/card/CardListMover.tsx
+++ b/src/components/shared/components/card/CardListMover.tsx
@@ -35,7 +35,7 @@ export const CardListMover = ({ data, onLikeClick }: CardProps) => {
     ? [
         {
           chipType: data.moveType,
-          status: data.requestStatus,
+          status: data.status,
           isTargeted: data.isTargeted,
         },
       ]

--- a/src/components/shared/components/card/CardListRequest.tsx
+++ b/src/components/shared/components/card/CardListRequest.tsx
@@ -26,7 +26,6 @@ export const CardListRequest = ({
   const chips: ChipData[] = [
     {
       chipType: data.moveType,
-      status: data.requestStatus,
       isTargeted: data.isTargeted,
     },
   ];

--- a/src/components/shared/components/card/CardListSave.tsx
+++ b/src/components/shared/components/card/CardListSave.tsx
@@ -46,7 +46,6 @@ export const CardListSave = ({
     ? [
         {
           chipType: data.moveType,
-          status: data.requestStatus,
           isTargeted: data.isTargeted,
         },
       ]

--- a/src/components/shared/components/card/CardListWait.tsx
+++ b/src/components/shared/components/card/CardListWait.tsx
@@ -6,7 +6,6 @@ import { EstimateOffer } from "@/src/types/estimate";
 import { ChipData } from "@/src/types/card";
 import {
   EstimateOfferStatus,
-  EstimateRequestStatus,
   MinimalAddress,
   ServiceType,
 } from "@/src/types/common";
@@ -15,6 +14,7 @@ import { MoverProfile } from "@/src/types/auth";
 // PendingEstimate.tsx에서 쓰는 card 데이터 타입
 export interface PendingEstimateCardData {
   estimateRequestId: string;
+  toAddressMinimal: MinimalAddress;
   fromAddressMinimal: MinimalAddress;
   isConfirmed: boolean;
   isTargeted: boolean;
@@ -22,8 +22,6 @@ export interface PendingEstimateCardData {
   moveType: ServiceType;
   price: number;
   offerStatus: EstimateOfferStatus;
-  requestStatus: EstimateRequestStatus;
-  toAddressMinimal: MinimalAddress;
   mover: MoverProfile;
 }
 
@@ -40,6 +38,12 @@ export const CardListWait = ({
   onConfirmClick,
   onDetailClick,
 }: CardProps) => {
+  const status =
+    "offerStatus" in data
+      ? data.offerStatus
+      : "status" in data
+        ? data.status
+        : undefined;
   // 카드 데이터
   const info = data.mover;
 
@@ -47,7 +51,7 @@ export const CardListWait = ({
   const chips: ChipData[] = [
     {
       chipType: data.moveType,
-      status: data.requestStatus,
+      status,
       isTargeted: data.isTargeted,
     },
   ];

--- a/src/components/shared/components/card/CardListWriteReview.tsx
+++ b/src/components/shared/components/card/CardListWriteReview.tsx
@@ -4,7 +4,6 @@ import { ChipData } from "@/src/types/card";
 import Image from "next/image";
 import { formatKoreanDate } from "@/src/lib/formatKoreanDate";
 import { reviewableOffers } from "@/src/api/review/api";
-import { ServiceType } from "@/src/types/common";
 
 interface CardProps {
   data: reviewableOffers;

--- a/src/components/shared/components/chip/ChipCategory.tsx
+++ b/src/components/shared/components/chip/ChipCategory.tsx
@@ -56,6 +56,13 @@ export const ChipCategory = ({
       img: null,
       alt: "견적 확정",
     },
+    COMPLETED: {
+      label: "견적 확정",
+      bg: theme.palette.Background[100],
+      text: theme.palette.PrimaryBlue[400],
+      img: null,
+      alt: "견적 확정",
+    },
   } as const;
 
   const sizeMap = {
@@ -86,19 +93,28 @@ export const ChipCategory = ({
   const size = forceMobileSize ? "sm" : isSmall ? "xs" : isMobile ? "sm" : "md";
   const sizeStyle = sizeMap[size as "xs" | "sm" | "md"];
 
+  const chipTypes = Array.isArray(data.chipType)
+    ? data.chipType
+    : data.chipType
+      ? [data.chipType]
+      : [];
+
   // ✅ category를 배열로 설정
   const categories: (keyof typeof categoryData)[] = [];
+  console.log("chip이 받은 데이터", categories);
 
-  if (data.isTargeted) categories.push("TARGET");
+  // 상태 값 하나만 나오게 설정
   if (data.status === "PENDING") categories.push("PENDING");
-  if (data.status === "CONFIRMED") categories.push("CONFIRMED");
-  if (
-    data.chipType === "SMALL" ||
-    data.chipType === "HOME" ||
-    data.chipType === "OFFICE"
-  ) {
-    categories.push(data.chipType);
-  }
+  else if (data.status === "COMPLETED") categories.push("COMPLETED");
+  else if (data.status === "CONFIRMED") categories.push("CONFIRMED");
+
+  // 서비스 타입 배열도 가능하게 설정
+  chipTypes.forEach((type) => {
+    if (type === "SMALL" || type === "HOME" || type === "OFFICE") {
+      categories.push(type);
+    }
+  });
+  if (data.isTargeted) categories.push("TARGET");
 
   if (!data || categories.length === 0) return null;
 

--- a/src/components/shared/components/chip/ChipCategory.tsx
+++ b/src/components/shared/components/chip/ChipCategory.tsx
@@ -101,7 +101,6 @@ export const ChipCategory = ({
 
   // ✅ category를 배열로 설정
   const categories: (keyof typeof categoryData)[] = [];
-  console.log("chip이 받은 데이터", categories);
 
   // 상태 값 하나만 나오게 설정
   if (data.status === "PENDING") categories.push("PENDING");

--- a/src/components/shared/components/modal/SendEstimateModal.tsx
+++ b/src/components/shared/components/modal/SendEstimateModal.tsx
@@ -20,7 +20,6 @@ import { ChipCategory } from "../chip/ChipCategory";
 import { ServiceType } from "@/src/types/common";
 import { Outline } from "../text-field/Outline";
 import { InfoChip } from "./components/InfoChip";
-import { EstimateRequestStatus } from "@/src/types/common";
 import { formatDateWithDay } from "@/src/lib/formatKoreanDate";
 
 interface SendEstimateModalProps {
@@ -45,7 +44,6 @@ export default function SendEstimateModal({
   customerName,
   moveDate,
   isTargeted,
-  requestStatus,
   fromAddress,
   toAddress,
   isLoading,
@@ -133,7 +131,6 @@ export default function SendEstimateModal({
                 data={{
                   chipType: type,
                   isTargeted,
-                  status: requestStatus as EstimateRequestStatus,
                 }}
               />
             ))}

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -5,8 +5,8 @@ import {
 } from "./common";
 
 export interface ChipData {
-  chipType?: ServiceType;
-  status?: EstimateRequestStatus | EstimateOfferStatus;
+  chipType?: ServiceType | ServiceType[];
+  status?: EstimateOfferStatus | EstimateRequestStatus;
   isTargeted?: boolean;
 }
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -44,8 +44,7 @@ export type Notification = {
 };
 
 enum EstimateOfferStatus {
-  REQUESTED = "REQUESTED", // 고객이 견적 요청 보냄 (기사 입장에선 대기 중)
-  SUBMITTED = "SUBMITTED", // 기사님이 견적서 보냄
+  PENDING = "PENDING", // 고객이 견적 요청 보냄 (기사 입장에선 대기 중)
   REJECTED = "REJECTED", // 기사님이 반려함
   CONFIRMED = "CONFIRMED", // 고객이 확정함
   CANCELED = "CANCELED", // 고객이 다른 기사 선택 → 자동 취소


### PR DESCRIPTION
## 🧚 변경사항 설명

chip status를 offer 기준으로 통일하였고 chip serviceType을 배열로도 받을 수 있게 수정하였습니다
거기에 맞게 card들을 수정 하여서 잘 나오는지 다 확인 하였습니다
보시다가 안되는 곳 있으면 말씀해주세요 수정하겠습니다

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

be92b0bde05d4b85343e3135ed1c1b93cd963d9a : 백엔드에 맞게 OfferStatus을 수정 하였습니다
d43c82186ea499fc0fa219762e8eb263bfedfb13 : chip serviceType을 배열로도 받을 수 있게 수정하였고 status가 COMPLETED일 때도 견적 확정이 되게 수정하였습니다
8997be4abec834474010436c08668b06abdaf3f1 : chip status를 offer 기준으로 맞추면서 card도 같이 수정 하였습니다
e205240dd07ebbd12247ece9c00e8698ea579b89 : 백엔드에 맞게 OfferStatus을 수정 하면서 거기에 맞게 다른 곳도 수정하였습니다
d3165475067ce32a14b1151d1ad699657ab74b01 : 견적 상세보기에 반응형이 안된 부분이랑 chip status에 알맞게 넣기 위해 수정 하였습니다

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
