### PR TITLE
QA-fix: 견적 요청 시 출발지/도착지 입력 UI 및 동작(카카오 우편서비스 창 바로 뜨도록) 수정

### DIFF
--- a/src/components/customer/request/steps/Step3_AddressSelect.tsx
+++ b/src/components/customer/request/steps/Step3_AddressSelect.tsx
@@ -117,7 +117,6 @@ export default function Step3_AddressSelect({
       <AddressModal
         open={openFromModal}
         onClose={() => setOpenFromModal(false)}
-        title={t("출발지를 선택해주세요")}
         onSelect={handleSelectFrom}
       />
 
@@ -125,7 +124,6 @@ export default function Step3_AddressSelect({
       <AddressModal
         open={openToModal}
         onClose={() => setOpenToModal(false)}
-        title={t("도착지를 선택해주세요")}
         onSelect={handleSelectTo}
       />
 

--- a/src/components/shared/components/address-card/AddressModal.tsx
+++ b/src/components/shared/components/address-card/AddressModal.tsx
@@ -1,26 +1,7 @@
-import React, { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Typography,
-  Box,
-  styled,
-  Button,
-} from "@mui/material";
-import { SearchInput } from "../text-field/Search";
-import AddressCard from "./AddressCard";
-import Image from "next/image";
+import React, { useEffect } from "react";
+import { Dialog } from "@mui/material";
 import { convertSidoToEnglish } from "@/src/utils/parseAddress";
 import { ModalAddress } from "@/src/utils/parseAddress";
-import { useTranslation } from "react-i18next";
-
-interface Address {
-  zipCode: string;
-  roadAddress: string;
-  jibunAddress: string;
-}
 
 interface AddressModalProps {
   open: boolean;
@@ -29,51 +10,11 @@ interface AddressModalProps {
   title?: string;
 }
 
-const StyledDialog = styled(Dialog)(({ theme }) => ({
-  "& .MuiDialog-paper": {
-    width: "100%",
-    maxWidth: "560px",
-    borderRadius: "20px",
-    margin: "16px",
-  },
-}));
-
-const StyledDialogTitle = styled(DialogTitle)({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  padding: "24px",
-});
-
-const StyledDialogContent = styled(DialogContent)({
-  padding: "0 24px 24px 24px",
-});
-
-const StyledButton = styled(Button)(({ theme }) => ({
-  width: "100%",
-  height: "56px",
-  borderRadius: "16px",
-  marginTop: "24px",
-  fontSize: ["16px", "16px", "20px"],
-  fontWeight: "semibold",
-  "&.Mui-disabled": {
-    backgroundColor: theme.palette.Grayscale[200],
-    color: theme.palette.White[100],
-  },
-}));
-
 const AddressModal: React.FC<AddressModalProps> = ({
   open,
   onClose,
   onSelect,
-  title,
 }) => {
-  const [searchValue, setSearchValue] = useState("");
-  const [addresses, setAddresses] = useState<ModalAddress[]>([]);
-  const [selectedAddress, setSelectedAddress] = useState<ModalAddress | null>(
-    null
-  );
-  const { t } = useTranslation();
   /**
    * 카카오 우편번호 서비스 API 연동 방법:
    * 1. 카카오 개발자 센터에서 JavaScript 앱 키를 발급받습니다.
@@ -93,8 +34,9 @@ const AddressModal: React.FC<AddressModalProps> = ({
    */
 
   // ✅ 추가: 카카오 주소 검색 팝업 호출 함수
-  const openKakaoPostcode = () => {
-    if (typeof window === "undefined") return;
+  useEffect(() => {
+    if (!open || typeof window === "undefined" || !window.daum?.Postcode)
+      return;
 
     new window.daum.Postcode({
       oncomplete: function (data) {
@@ -111,101 +53,17 @@ const AddressModal: React.FC<AddressModalProps> = ({
           fullAddress,
         };
 
-        // ✅ 주소 선택 및 반영
-        setSelectedAddress(parsedAddress);
-        setSearchValue(data.roadAddress);
-        setAddresses([parsedAddress]); // ✅ 한 건만 표시
+        // ✅ 선택한 주소 전달 후 모달 닫기
+        onSelect(parsedAddress);
+        onClose();
       },
+      onclose: onClose,
     }).open();
-  };
-
-  // const handleSearch = (value: string) => {
-  //   setSearchValue(value);
-  //   // TODO: 카카오 우편번호 서비스 API 연동
-  //   // 임시 데이터
-  //   setAddresses([
-  //     {
-  //       zipCode: "04538",
-  //       roadAddress: "서울 중구 삼일대로 343 (대신파이낸스센터)",
-  //       jibunAddress: "서울 중구 저동1가 114",
-  //     },
-  //   ]);
-  // };
-
-  // const handleAddressSelect = (address: Address) => {
-  //   setSelectedAddress(address);
-  // };
-
-  const handleComplete = () => {
-    if (selectedAddress) {
-      onSelect(selectedAddress);
-      onClose();
-    }
-  };
+  }, [open, onClose, onSelect]);
 
   return (
-    <StyledDialog open={open} onClose={onClose} fullWidth>
-      <StyledDialogTitle>
-        <Typography
-          fontWeight="semibold"
-          sx={{
-            fontSize: ["18px", "18px", "24px"],
-          }}
-        >
-          {title}
-        </Typography>
-        <IconButton onClick={onClose}>
-          <Image
-            src="/Images/header/X.svg"
-            alt="close"
-            width={24}
-            height={24}
-          />
-        </IconButton>
-      </StyledDialogTitle>
-      <StyledDialogContent>
-        <Box mb={3}>
-          <SearchInput
-            variation="right"
-            placeholder={t("도로명, 지번, 건물명으로 검색")}
-            value={searchValue}
-            onChange={(e) => setSearchValue(e.target.value)} // ✅ 검색어 입력 가능
-            onClick={openKakaoPostcode} // ✅ 검색 아이콘 클릭 시 카카오 팝업 호출
-            onDeleteClick={() => setSearchValue("")}
-          />
-        </Box>
-        <Box>
-          {addresses.map((address, index) => (
-            <AddressCard
-              key={index}
-              zipCode={address.zipCode}
-              roadAddress={address.roadAddress}
-              jibunAddress={address.jibunAddress}
-              selected={selectedAddress?.zipCode === address.zipCode}
-              onClick={() => setSelectedAddress(address)}
-              // zipCode={address.zipCode}
-              // roadAddress={address.roadAddress}
-              // jibunAddress={address.jibunAddress}
-              // onClick={() => handleAddressSelect(address)}
-              // selected={selectedAddress?.zipCode === address.zipCode}
-            />
-          ))}
-        </Box>
-        <StyledButton
-          variant="contained"
-          disabled={!selectedAddress}
-          onClick={handleComplete}
-          sx={(theme) => ({
-            backgroundColor: selectedAddress
-              ? theme.palette.PrimaryBlue[300]
-              : undefined,
-            fontSize: ["16px", "16px", "20px"],
-          })}
-        >
-          {t("선택완료")}
-        </StyledButton>
-      </StyledDialogContent>
-    </StyledDialog>
+    // ✅ UI 없는 빈 다이얼로그. 화면에는 표시되지 않음
+    <Dialog open={open} onClose={onClose} />
   );
 };
 

--- a/src/components/shared/components/input/InputAddress.tsx
+++ b/src/components/shared/components/input/InputAddress.tsx
@@ -44,12 +44,13 @@ export const EditableBox = ({
       boxSizing={"border-box"}
     >
       {/* 출발지 */}
-      <Box
-        display={"flex"}
-        flexDirection={"column"}
-        alignItems={"flex-end"}
-        gap={"8px"}
-      >
+      <Box display={"flex"} flexDirection={"column"} gap={"8px"}>
+        <Typography
+          variant={isSmall ? "M_14" : "M_18"}
+          sx={{ color: COLORS.Black[400] }}
+        >
+          출발지
+        </Typography>
         <Button
           variant="outlined"
           onClick={onFromClick}
@@ -73,6 +74,7 @@ export const EditableBox = ({
               color: COLORS.Black[400],
               cursor: "pointer",
               textDecoration: "underline",
+              textAlign: "end",
             }}
           >
             {t("수정하기")}
@@ -81,12 +83,13 @@ export const EditableBox = ({
       </Box>
 
       {/* 도착지 */}
-      <Box
-        display={"flex"}
-        flexDirection={"column"}
-        alignItems={"flex-end"}
-        gap={"8px"}
-      >
+      <Box display={"flex"} flexDirection={"column"} gap={"8px"}>
+        <Typography
+          variant={isSmall ? "M_14" : "M_18"}
+          sx={{ color: COLORS.Black[400] }}
+        >
+          도착지
+        </Typography>
         <Button
           variant="outlined"
           onClick={onToClick}
@@ -110,6 +113,7 @@ export const EditableBox = ({
               color: COLORS.Black[400],
               cursor: "pointer",
               textDecoration: "underline",
+              textAlign: "end",
             }}
           >
             {t("수정하기")}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,19 +1,24 @@
-interface DaumPostcodeData {
-  zonecode: string;
-  roadAddress: string;
-  jibunAddress: string;
-}
+export {};
 
-interface DaumPostcodeOptions {
-  oncomplete: (data: DaumPostcodeData) => void;
-}
+declare global {
+  interface DaumPostcodeData {
+    zonecode: string;
+    roadAddress: string;
+    jibunAddress: string;
+  }
 
-interface DaumPostcode {
-  open(): void;
-}
+  interface DaumPostcodeOptions {
+    oncomplete: (data: DaumPostcodeData) => void;
+    onclose?: () => void;
+  }
 
-interface Window {
-  daum: {
-    Postcode: new (options: DaumPostcodeOptions) => DaumPostcode;
-  };
+  interface DaumPostcode {
+    open(): void;
+  }
+
+  interface Window {
+    daum: {
+      Postcode: new (options: DaumPostcodeOptions) => DaumPostcode;
+    };
+  }
 }


### PR DESCRIPTION
## 🧚 변경사항 설명

QA-[주소입력input Daum우편서비스 연동](https://www.notion.so/input-Daum-21dd9fa672ba80228739f277184a2a0c?source=copy_link) 작업 완료
- 카카오 우편번호 서비스는 외부에서 검색어를 전달해서 직접 검색을 실행할 수 없는 것으로 확인되어서, 하단 페이지 피그마에서 빨간색 표시한 버튼 클릭 시 바로 카카오 우편서비스 창이 열리도록 수정
![image](https://github.com/user-attachments/assets/d4fc0c57-3f48-439a-b8a8-9f0d94b7a6a3)


## 🧑🏻‍🏫 To-do

- [ ] 견적요청하고나서 저장해놓은 requestStore 리셋하는 훅 제작(브랜치 새로파기)
- [ ] 발표 대본 작성

## 🎤 공유 사항

x

## 🤙🏻 관련 이슈

#144  에서 작성한 To-do 하나 완료

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/bf702a35-ec76-478b-8af1-97fc2a68ec8e)