### PR TITLE
refactor: oauth 로그인 실패시 에러 메시지를 GET 파라미터로 전달하여 프론트엔드에서 스낵바 처리

### DIFF
--- a/src/app/[lng]/auth/mover/login/page.tsx
+++ b/src/app/[lng]/auth/mover/login/page.tsx
@@ -18,10 +18,13 @@ import {
 } from "@/src/lib/authConstants";
 import { useLoginForm } from "@/src/hooks/auth/hook";
 import { LoginSchemaType } from "@/src/schemas/auth/login.schema";
+import { useEffect } from "react";
+import { useSnackbar } from "@/src/hooks/snackBarHooks";
 
 const Login = () => {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down("tablet"));
+  const { openSnackbar } = useSnackbar();
 
   const {
     register,
@@ -37,6 +40,24 @@ const Login = () => {
   const isAllFilled = requiredFields.every(
     (field) => values[field]?.trim() !== ""
   );
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const errorMessage = urlParams.get("error");
+    if (errorMessage) {
+      let message = errorMessage;
+      try {
+        const parsed = JSON.parse(decodeURIComponent(errorMessage));
+        if (parsed.message) {
+          message = parsed.message;
+        }
+      } catch {
+        message = decodeURIComponent(errorMessage);
+      }
+      openSnackbar(message, "error");
+    }
+  }, [openSnackbar]);
+
   return (
     <Stack
       justifySelf={"center"}

--- a/src/app/[lng]/auth/mover/signup/page.tsx
+++ b/src/app/[lng]/auth/mover/signup/page.tsx
@@ -20,10 +20,13 @@ import {
 } from "@/src/lib/authConstants";
 import { useSignupForm } from "@/src/hooks/auth/hook";
 import { SignUpSchemaType } from "@/src/schemas/auth/signup.schema";
+import { useEffect } from "react";
+import { useSnackbar } from "@/src/hooks/snackBarHooks";
 
 const SignUp = () => {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down("tablet"));
+  const { openSnackbar } = useSnackbar();
 
   const {
     register,
@@ -43,6 +46,23 @@ const SignUp = () => {
   const isAllFilled = requiredFields.every(
     (field) => values[field]?.trim() !== ""
   );
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const errorMessage = urlParams.get("error");
+    if (errorMessage) {
+      let message = errorMessage;
+      try {
+        const parsed = JSON.parse(decodeURIComponent(errorMessage));
+        if (parsed.message) {
+          message = parsed.message;
+        }
+      } catch {
+        message = decodeURIComponent(errorMessage);
+      }
+      openSnackbar(message, "error");
+    }
+  }, [openSnackbar]);
 
   return (
     <Stack

--- a/src/app/[lng]/auth/user/login/page.tsx
+++ b/src/app/[lng]/auth/user/login/page.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/src/lib/authConstants";
 import { useLoginForm } from "@/src/hooks/auth/hook";
 import { LoginSchemaType } from "@/src/schemas/auth/login.schema";
+import { useEffect } from "react";
+import { useSnackbar } from "@/src/hooks/snackBarHooks";
 
 const Login = () => {
   const theme = useTheme();
@@ -29,6 +31,7 @@ const Login = () => {
     watch,
     formState: { errors },
   } = useLoginForm("CUSTOMER");
+  const { openSnackbar } = useSnackbar();
 
   const requiredFields: (keyof LoginSchemaType)[] = ["email", "password"];
 
@@ -36,6 +39,24 @@ const Login = () => {
   const isAllFilled = requiredFields.every(
     (field) => values[field]?.trim() !== ""
   );
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const errorMessage = urlParams.get("error");
+    if (errorMessage) {
+      let message = errorMessage;
+      try {
+        const parsed = JSON.parse(decodeURIComponent(errorMessage));
+        if (parsed.message) {
+          message = parsed.message;
+        }
+      } catch {
+        message = decodeURIComponent(errorMessage);
+      }
+      openSnackbar(message, "error");
+    }
+  }, [openSnackbar]);
+
   return (
     <Stack
       justifySelf={"center"}

--- a/src/app/[lng]/auth/user/signup/page.tsx
+++ b/src/app/[lng]/auth/user/signup/page.tsx
@@ -19,10 +19,13 @@ import {
 } from "@/src/lib/authConstants";
 import { useSignupForm } from "@/src/hooks/auth/hook";
 import { SignUpSchemaType } from "@/src/schemas/auth/signup.schema";
+import { useEffect } from "react";
+import { useSnackbar } from "@/src/hooks/snackBarHooks";
 
 const SignUp = () => {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down("tablet"));
+  const { openSnackbar } = useSnackbar();
 
   const {
     register,
@@ -42,6 +45,23 @@ const SignUp = () => {
   const isAllFilled = requiredFields.every(
     (field) => values[field]?.trim() !== ""
   );
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const errorMessage = urlParams.get("error");
+    if (errorMessage) {
+      let message = errorMessage;
+      try {
+        const parsed = JSON.parse(decodeURIComponent(errorMessage));
+        if (parsed.message) {
+          message = parsed.message;
+        }
+      } catch {
+        message = decodeURIComponent(errorMessage);
+      }
+      openSnackbar(message, "error");
+    }
+  }, [openSnackbar]);
 
   return (
     <Stack


### PR DESCRIPTION
## 🧚 변경사항 설명
- 소셜 로그인시 이미 로컬로 가입된 계정과 이메일이 동일할 경우에 백엔드로 redirect가 되면서 json 형태로 메시지 출력되던 부분 해결
- 프론트엔드로 리다이렉트하면서 에러 메시지를 GET 파라미터로 전달하여 프론트에서 전달받은 내용을 스낵바 처리하도록 함

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷
- Before
![image](https://github.com/user-attachments/assets/0b7f4afe-8c05-44f6-88d0-2d6b62396593)

- After
![Screenshot 2025-06-30 121734](https://github.com/user-attachments/assets/575deef4-48b1-46a5-acc7-fe4f4a573b56)