### PR TITLE
fix: 견적 요청 시 프로필 미생성 오류 처리 추가

### DIFF
--- a/src/components/customer/request/steps/Step3_AddressSelect.tsx
+++ b/src/components/customer/request/steps/Step3_AddressSelect.tsx
@@ -92,7 +92,11 @@ export default function Step3_AddressSelect({
             "error"
           );
           router.replace(PATH.userProfileRegister);
-          return;
+        } else {
+          openSnackbar(
+            t("견적 확정에 실패했습니다. 다시 시도해주세요."),
+            "error"
+          );
         }
       }
       console.error(error);

--- a/src/components/customer/request/steps/Step3_AddressSelect.tsx
+++ b/src/components/customer/request/steps/Step3_AddressSelect.tsx
@@ -14,6 +14,7 @@ import { postEstimateRequest } from "@/src/api/customer/request/api";
 import { parseAddress, ModalAddress } from "@/src/utils/parseAddress";
 import { PATH } from "@/src/lib/constants";
 import { useTranslation } from "react-i18next";
+import { AxiosError } from "axios";
 
 type ParsedAddress = {
   sido: string; // 시도
@@ -84,7 +85,16 @@ export default function Step3_AddressSelect({
       openSnackbar(t("견적 확정 완료"), "success", 5000);
       router.replace(PATH.moverList);
     } catch (error) {
-      openSnackbar(t("견적 확정에 실패했습니다. 다시 시도해주세요."), "error");
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 404) {
+          openSnackbar(
+            t("견적 요청을 위해 먼저 프로필을 생성해주세요!"),
+            "error"
+          );
+          router.replace(PATH.userProfileRegister);
+          return;
+        }
+      }
       console.error(error);
     }
   };


### PR DESCRIPTION
## 🧚 변경사항 설명
- 고객이 프로필이 없을때 견적 요청시 불명확한 에러 처리를 구체화 하고 프로필 생성 페이지로 라우팅 요청 추가하였습니다.
<!-- 이 PR에서 어떤 변경사항이 있었는지 설명해주세요 -->

## 📸 스크린샷
- 변경 전 : 404에러시 프론트에서 불명확한 에러 메세지 전달
<img width="1488" alt="Screenshot 2025-06-30 at 1 53 15 pm" src="https://github.com/user-attachments/assets/5f187cd0-63e3-4e51-9fec-59dcda4fb9ee" />

- 변경 후

https://github.com/user-attachments/assets/fc6386ac-8f2c-4dbc-af3b-728c994c0fba




<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
