### PR TITLE
fix: 견적 요청 페이지_ 접속 시 견적확정했었거나 다른 유저인 경우 requestStore reset

### DIFF
--- a/src/components/customer/request/EstimateRequestFlow.tsx
+++ b/src/components/customer/request/EstimateRequestFlow.tsx
@@ -28,6 +28,8 @@ export default function EstimateRequestFlow() {
   const isSmall = useMediaQuery(theme.breakpoints.down("tablet"));
   const router = useRouter();
   const { openSnackbar } = useSnackbarStore();
+  const reset = useEstimateStore((state) => state.reset);
+
   const [isLoading, setIsLoading] = useState(true);
   const { t } = useTranslation();
   // 0. zustand 상태 가져오기
@@ -52,19 +54,19 @@ export default function EstimateRequestFlow() {
   useEffect(() => {
     if (!userIdOrToken) return;
 
-    // 2. 새 유저 로그인 시 기존 localStorage 초기화
+    // 2. 새 유저 로그인 시 zustand 메모리 상태 초기화
     const prevUser = localStorage.getItem("prevUserId");
     if (prevUser !== userIdOrToken && userIdOrToken) {
       localStorage.setItem("prevUserId", userIdOrToken);
       useEstimateStore.persist.clearStorage();
-      useEstimateStore.setState({
-        moveType: "",
-        moveDate: "",
-        fromAddress: null,
-        toAddress: null,
-        step: null,
-      });
+      reset();
     }
+
+    // 수동으로 저장한 localStorage 항목도 제거
+    localStorage.removeItem("moveType");
+    localStorage.removeItem("moveDate");
+    localStorage.removeItem("fromAddress");
+    localStorage.removeItem("toAddress");
   }, [userIdOrToken]);
 
   const isReady = typeof window !== "undefined" && isLogin;

--- a/src/components/customer/request/steps/Step3_AddressSelect.tsx
+++ b/src/components/customer/request/steps/Step3_AddressSelect.tsx
@@ -41,6 +41,7 @@ export default function Step3_AddressSelect({
   const router = useRouter();
   const { t } = useTranslation();
   const { moveType, moveDate, toAddress, fromAddress } = useEstimateStore();
+  const reset = useEstimateStore((state) => state.reset);
 
   const [openFromModal, setOpenFromModal] = useState(false);
   const [openToModal, setOpenToModal] = useState(false);
@@ -80,6 +81,16 @@ export default function Step3_AddressSelect({
         fromAddress: fromAddress!,
         toAddress: toAddress!,
       });
+
+      // 견적 확정 성공 후 로컬스토리지 초기화
+      localStorage.removeItem("estimate-storage");
+      localStorage.removeItem("fromAddress");
+      localStorage.removeItem("toAddress");
+      localStorage.removeItem("moveDate");
+      localStorage.removeItem("moveType");
+
+      // zustand 상태 초기화
+      reset();
 
       openSnackbar(t("견적 확정 완료"), "success", 5000);
       router.replace(PATH.moverList);

--- a/src/store/requestStore.ts
+++ b/src/store/requestStore.ts
@@ -15,7 +15,7 @@ type EstimateState = {
   setStep: (step: number | null) => void;
 };
 
-export const useEstimateStore = create<EstimateState>()(
+export const useEstimateStore = create<EstimateState & { reset: () => void }>()(
   persist(
     (set) => ({
       moveType: "",
@@ -28,9 +28,17 @@ export const useEstimateStore = create<EstimateState>()(
       setFromAddress: (addr) => set({ fromAddress: addr }),
       setToAddress: (addr) => set({ toAddress: addr }),
       setStep: (step) => set({ step }),
+      reset: () =>
+        set({
+          moveType: "",
+          moveDate: "",
+          fromAddress: null,
+          toAddress: null,
+          step: null,
+        }),
     }),
     {
-      name: "estimate-storage", // localStorage 키 이름
+      name: "estimate-storage",
     }
   )
 );

--- a/src/store/requestStore.ts
+++ b/src/store/requestStore.ts
@@ -3,8 +3,8 @@ import { persist } from "zustand/middleware";
 import { ParsedAddress } from "../utils/parseAddress";
 
 type EstimateState = {
-  moveType: string;
-  moveDate: string;
+  moveType: string | null;
+  moveDate: string | null;
   fromAddress: ParsedAddress | null;
   toAddress: ParsedAddress | null;
   step: number | null; // 견적요청 Progress 게이지 바를 header로 사용하기 위해 추가
@@ -18,8 +18,8 @@ type EstimateState = {
 export const useEstimateStore = create<EstimateState & { reset: () => void }>()(
   persist(
     (set) => ({
-      moveType: "",
-      moveDate: "",
+      moveType: null,
+      moveDate: null,
       fromAddress: null,
       toAddress: null,
       step: null,
@@ -30,8 +30,8 @@ export const useEstimateStore = create<EstimateState & { reset: () => void }>()(
       setStep: (step) => set({ step }),
       reset: () =>
         set({
-          moveType: "",
-          moveDate: "",
+          moveType: null,
+          moveDate: null,
           fromAddress: null,
           toAddress: null,
           step: null,


### PR DESCRIPTION
## 🧚 변경사항 설명

일반유저-견적 요청 페이지 접속 시, 이전에 '견적 확정하기'버튼을 눌러 한번 견적을 보낸 적이 있거나 다른 유저로 로그인한 경우, requestStore를 reset하는 로직 추가했습니다. 

## 🧑🏻‍🏫 To-do

- [ ] [QA 기사님-받은요청페이지 무한스크롤 시 스켈레톤 추가](https://www.notion.so/isLoading-CircularProgress-21bd9fa672ba806aa4c7f47b7a4b7576?source=copy_link) 진행해보려고 합니다.
- [x] 발표자료에 다국어 번역 기능 내용 추가
- [x] 발표 대본 작성

## 🎤 공유 사항

~~조순님이 로컬에서 열어놔주셨던 서버 닫혔는지 pending뜨다가 요청 안보내지고 로그인 안돼서 테스트를 못해봤네요. 수업시간에 화면공유나 말씀드리면서 확인해봐야할 것 같습니다. ㅠㅠ 확인후에 머지할게요~~
=>새로고침 시에는 moveType, moveDate,  fromAddress, toAddress 입력값으로 바로 입력 가능 / 다른 계정으로 로그인 시에는  처음부터 입력하도록 리셋 기능 제대로 동작하는 것 확인 

## 🤙🏻 관련 이슈


## 📸 스크린샷

